### PR TITLE
Use F key to send camera to the center of the world

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This package includes a basic template for a 3D city builder in Godot 4.1.1.stab
 | Key | Command |
 | --- | --- |
 | <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> | Move camera |
+| <kbd>F</kbd> | Camera to center |
 | <kbd>Middle mouse button</kbd> | Hold to rotate camera |
 | <kbd>Left mouse button</kbd> | Place building |
 | <kbd>DEL</kbd> | Remove building |

--- a/project.godot
+++ b/project.godot
@@ -79,6 +79,11 @@ load={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194333,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+camera_center={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/scripts/view.gd
+++ b/scripts/view.gd
@@ -42,3 +42,7 @@ func _input(event):
 	if event is InputEventMouseMotion:
 		if Input.is_action_pressed("camera_rotate"):
 			camera_rotation += Vector3(0, -event.relative.x / 10, 0)
+
+	if event is InputEventKey:
+		if Input.is_action_pressed("camera_center"):
+			camera_position = Vector3()


### PR DESCRIPTION
If the the play wonders around too far, they can get lost in the void.
This PR adds the `F`key to allow them to easily go back to the center of the world.

Thank you for creating this, it's really great, as the rest of your work.
H.