### PR TITLE
Prevent selector position from overshooting.

### DIFF
--- a/scripts/builder.gd
+++ b/scripts/builder.gd
@@ -54,7 +54,7 @@ func _process(delta):
 		view_camera.project_ray_normal(get_viewport().get_mouse_position()))
 
 	var gridmap_position = Vector3(round(world_position.x), 0, round(world_position.z))
-	selector.position = lerp(selector.position, gridmap_position, delta * 40)
+	selector.position = lerp(selector.position, gridmap_position, min(delta * 40, 1.0))
 	
 	action_build(gridmap_position)
 	action_demolish(gridmap_position)


### PR DESCRIPTION
This makes the selector movement less jerky.