### PR TITLE
Fix: fixes memory leak in builder script

### DIFF
--- a/scripts/builder.gd
+++ b/scripts/builder.gd
@@ -123,6 +123,7 @@ func update_structure():
 	# Clear previous structure preview in selector
 	for n in selector_container.get_children():
 		selector_container.remove_child(n)
+		n.queue_free()
 		
 	# Create new structure preview in selector
 	var _model = structures[index].model.instantiate()


### PR DESCRIPTION
### Summary
This PR fixes a memory leak present in the builder script. In the `update_structure()` method the model preview is being removed from the scene tree but never actually garbage collected while the game continues to run (see: [Node.remove_child](https://docs.godotengine.org/en/4.5/classes/class_node.html#class-node-method-remove-child))

`update_strucure()` is called in `action_structure_toggle()`, which is being called every frame in `_process()`, resulting in the preview model being removed from the tree and re-instantiated every frame, but not garbage collected. This causes orphaned nodes and an increase in memory usage over time.

#### Before (~1m30s run time)
<img width="1646" height="249" alt="city_builder_kit_memory_leak" src="https://github.com/user-attachments/assets/311ce2cb-177e-46bf-803e-42cbbd6c654b" />

#### After (~1m30s run time)
<img width="1654" height="281" alt="city_builder_kit_memory_leak_fixed" src="https://github.com/user-attachments/assets/6c520849-6f8d-404b-9e4d-8cb8b533ae72" />
